### PR TITLE
feat: add tailwind-style flex and grid utilities

### DIFF
--- a/projects/kyrolus-sous-materials/styles/layout/_flex.scss
+++ b/projects/kyrolus-sous-materials/styles/layout/_flex.scss
@@ -24,11 +24,15 @@
     .flex-#{$bp-name}-fill {
       flex: 1 1 auto !important;
     }
-    @each $name, $value in $flex-shrink-values {
-      .flex-#{$bp-name}-grow-#{$name} {
+    @each $name, $value in $flex-grow-values {
+      $class: if($name == 1, "flex-#{$bp-name}-grow", "flex-#{$bp-name}-grow-#{$name}");
+      .#{$class} {
         flex-grow: $value !important;
       }
-      .flex-#{$bp-name}-shrink-#{$name} {
+    }
+    @each $name, $value in $flex-shrink-values {
+      $class: if($name == 1, "flex-#{$bp-name}-shrink", "flex-#{$bp-name}-shrink-#{$name}");
+      .#{$class} {
         flex-shrink: $value !important;
       }
     }
@@ -43,6 +47,9 @@
       .flex-basis-#{$bp-name}-#{$name} {
         flex-basis: $value;
       }
+      .basis-#{$bp-name}-#{$name} {
+        flex-basis: $value;
+      }
     }
     @each $name, $value in $flex-order-values {
       .flex-#{$bp-name}-#{$name} {
@@ -54,6 +61,14 @@
 
 // --- 3. BASE UTILITY GENERATION (for all screen sizes) ---
 
+// Display
+.flex {
+  display: flex !important;
+}
+.inline-flex {
+  display: inline-flex !important;
+}
+
 // Direction
 @each $name, $value in $flex-direction-values {
   .flex-#{$name} {
@@ -61,10 +76,25 @@
   }
 }
 
-// Wrap
+// Wrap (existing classes and Tailwind aliases)
 @each $name, $value in $flex-wrap-values {
   .flex-wrap-#{$name} {
     flex-wrap: $value !important;
+  }
+}
+@each $name, $value in $flex-wrap-values {
+  @if $name == wrap {
+    .flex-wrap {
+      flex-wrap: $value !important;
+    }
+  } @else if $name == wrap-reverse {
+    .flex-wrap-reverse {
+      flex-wrap: $value !important;
+    }
+  } @else if $name == nowrap {
+    .flex-nowrap {
+      flex-wrap: $value !important;
+    }
   }
 }
 
@@ -72,14 +102,19 @@
 .flex-fill {
   flex: 1 1 auto !important;
 }
-@each $name, $value in $flex-shrink-values {
-  .flex-grow-#{$name} {
+@each $name, $value in $flex-grow-values {
+  $class: if($name == 1, "flex-grow", "flex-grow-#{$name}");
+  .#{$class} {
     flex-grow: $value !important;
   }
-  .flex-shrink-#{$name} {
+}
+@each $name, $value in $flex-shrink-values {
+  $class: if($name == 1, "flex-shrink", "flex-shrink-#{$name}");
+  .#{$class} {
     flex-shrink: $value !important;
   }
 }
+
 @each $name, $value in $flex-order-values {
   .flex-#{$name} {
     flex: $value;
@@ -87,6 +122,9 @@
 }
 @each $name, $value in $flex-basis-values {
   .flex-basis-#{$name} {
+    flex-basis: $value;
+  }
+  .basis-#{$name} {
     flex-basis: $value;
   }
 }

--- a/projects/kyrolus-sous-materials/styles/layout/_grid.scss
+++ b/projects/kyrolus-sous-materials/styles/layout/_grid.scss
@@ -12,6 +12,20 @@ $grid-rows: 6;
 // Values for grid-auto-flow
 $grid-flow-values: ("row", "column", "row-dense", "column-dense");
 
+// Values for grid-auto-columns and grid-auto-rows
+$grid-auto-columns-values: (
+  auto: auto,
+  min: min-content,
+  max: max-content,
+  fr: minmax(0, 1fr)
+);
+$grid-auto-rows-values: (
+  auto: auto,
+  min: min-content,
+  max: max-content,
+  fr: minmax(0, 1fr)
+);
+
 // --- 2. RESPONSIVE UTILITY GENERATION (Mobile-First) ---
 
 @each $bp-name, $bp-value in $breakpoints {
@@ -78,6 +92,18 @@ $grid-flow-values: ("row", "column", "row-dense", "column-dense");
       grid-row-start: auto;
     }
 
+    // grid-auto-columns & grid-auto-rows
+    @each $name, $value in $grid-auto-columns-values {
+      .auto-cols-#{$bp-name}-#{$name} {
+        grid-auto-columns: $value !important;
+      }
+    }
+    @each $name, $value in $grid-auto-rows-values {
+      .auto-rows-#{$bp-name}-#{$name} {
+        grid-auto-rows: $value !important;
+      }
+    }
+
     // grid-auto-flow
     @each $name in $grid-flow-values {
       .grid-flow-#{$bp-name}-#{$name} {
@@ -88,6 +114,14 @@ $grid-flow-values: ("row", "column", "row-dense", "column-dense");
 }
 
 // --- 3. BASE UTILITY GENERATION (for all screen sizes) ---
+
+// Display
+.grid {
+  display: grid !important;
+}
+.inline-grid {
+  display: inline-grid !important;
+}
 
 // grid-template-*
 .grid-cols-none {
@@ -104,6 +138,18 @@ $grid-flow-values: ("row", "column", "row-dense", "column-dense");
 @for $i from 1 through $grid-rows {
   .grid-rows-#{$i} {
     grid-template-rows: repeat($i, minmax(0, 1fr)) !important;
+  }
+}
+
+// auto-cols & auto-rows
+@each $name, $value in $grid-auto-columns-values {
+  .auto-cols-#{$name} {
+    grid-auto-columns: $value !important;
+  }
+}
+@each $name, $value in $grid-auto-rows-values {
+  .auto-rows-#{$name} {
+    grid-auto-rows: $value !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- add Tailwind-style display, wrap, grow/shrink, and basis helpers for flex
- add grid display aliases plus auto-cols and auto-rows utilities

## Testing
- `npm test` *(fails: ng not found)*
- `npm install` *(fails: 403 Forbidden for kyrolus-sous-materials package)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2d89f50c832da5e8440008936dfb