### PR TITLE
chore: configure PostCSS autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "@angular/router": "^20.1.6",
     "@angular/ssr": "^20.1.5",
     "bootstrap-icons": "^1.13.1",
-    "kyrolus-sous-materials": "^1.0.0",
     "express": "^5.1.0",
+    "kyrolus-sous-materials": "^1.0.0",
     "material-icons": "^1.13.14",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
@@ -49,6 +49,7 @@
     "@types/jasmine": "~5.1.0",
     "@types/node": "^20.17.19",
     "@vitest/coverage-v8": "^3.2.4",
+    "autoprefixer": "^10.4.16",
     "cypress": "^14.5.4",
     "jasmine-core": "~5.8.0",
     "jsdom": "^26.1.0",
@@ -58,6 +59,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "ng-packagr": "^20.1.0",
+    "postcss": "^8.5.6",
     "typescript": "~5.8.2",
     "vitest": "^3.2.4"
   }

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,1 @@
+module.exports = { plugins: [require('autoprefixer')] };

--- a/projects/kyrolus-sous-materials/styles/styles.scss
+++ b/projects/kyrolus-sous-materials/styles/styles.scss
@@ -45,8 +45,6 @@
   right: 0;
   bottom: 0;
   visibility: hidden;
-  -webkit-transition: all 0.3s ease-in-out;
-  -o-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
   z-index: 2;
 }
@@ -65,33 +63,18 @@
 }
 
 .default-transition {
-  -webkit-transition-duration: 225ms;
-  -moz-transition-duration: 225ms;
-  -o-transition-duration: 225ms;
   transition-duration: 225ms;
-  -webkit-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  -moz-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  -o-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  -webkit-transition-delay: 0s;
-  -moz-transition-delay: 0s;
-  -o-transition-delay: 0s;
   transition-delay: 0s;
 }
 
 .default-filter-grayscale {
   filter: grayscale(1);
-  -webkit-filter: grayscale(1);
-  -moz-filter: grayscale(1);
-  -o-filter: grayscale(1);
 }
 
 .hover-effect {
   &:hover {
     filter: grayscale(0.6);
-    -webkit-filter: grayscale(0.6);
-    -moz-filter: grayscale(0.6);
-    -o-filter: grayscale(0.6);
   }
 }
 .text-stroke-white {
@@ -117,18 +100,10 @@
   to {
     transform: scale(9);
     opacity: 0;
-    -webkit-transform: scale(9);
-    -moz-transform: scale(9);
-    -ms-transform: scale(9);
-    -o-transform: scale(9);
   }
 }
 .scale-0 {
   transform: scale(0);
-  -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -ms-transform: scale(0);
-  -o-transform: scale(0);
 }
 
 .sidenav-toggle[opened="false"] {

--- a/projects/kyrolus-sous-materials/styles/utilities/_utilities.scss
+++ b/projects/kyrolus-sous-materials/styles/utilities/_utilities.scss
@@ -558,26 +558,6 @@ $border-radius-sides: (
 }
 
 .placeholder-transparent {
-  &::-webkit-input-placeholder {
-    color: transparent;
-  }
-
-  &:-moz-placeholder {
-    color: transparent;
-  }
-
-  &::-moz-placeholder {
-    color: transparent;
-  }
-
-  &:-ms-input-placeholder {
-    color: transparent;
-  }
-
-  &::-ms-input-placeholder {
-    color: transparent;
-  }
-
   &::placeholder {
     color: transparent;
   }


### PR DESCRIPTION
## Summary
- add autoprefixer and postcss dev dependencies
- configure postcss with autoprefixer
- drop manual vendor prefixes from styles

## Testing
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7808a404832db5fc1b2910aa627f