### PR TITLE
fix: correct primary color variable name

### DIFF
--- a/projects/kyrolus-sous-materials/styles/abstracts/_variables.scss
+++ b/projects/kyrolus-sous-materials/styles/abstracts/_variables.scss
@@ -61,7 +61,7 @@ $display-values: (
 $hover-darken: -20%;
 $active-darken: -40%;
 
-$primay-color: #2563eb;
+$primary-color: #2563eb;
 $secondary-color: #9db44f;
 $success-color: #10b981;
 $danger-color: #dc2626;
@@ -75,7 +75,7 @@ $tertiary: color.change(#7c3aed, $lightness: 20%);
 
 // الألوان الرئيسية والثانوية والرسائل
 $colors: (
-  "primary": $primay-color,
+  "primary": $primary-color,
   "secondary": $secondary-color,
   "success": $success-color,
   "danger": $danger-color,
@@ -216,7 +216,7 @@ $default-font-family: "Roboto", sans-serif;
 $default-line-height: 1.5;
 
 :root {
-  --primary-color: #{$primay-color};
+  --primary-color: #{$primary-color};
   --secondary-color: #{$secondary-color};
   --success-color: #{$success-color};
   --danger-color: #{$danger-color};

--- a/projects/kyrolus-sous-materials/styles/components/_button.scss
+++ b/projects/kyrolus-sous-materials/styles/components/_button.scss
@@ -21,10 +21,10 @@ $btn-sizes: (
 
 $btn-colors: (
   "primary": (
-    bg: $primay-color,
+    bg: $primary-color,
     color: #ffffff,
-    hover: color.scale($primay-color, $lightness: $hover-darken),
-    active: color.scale($primay-color, $lightness: $active-darken),
+    hover: color.scale($primary-color, $lightness: $hover-darken),
+    active: color.scale($primary-color, $lightness: $active-darken),
   ),
   "secondary": (
     bg: $secondary-color,
@@ -76,9 +76,9 @@ $btn-colors: (
   ),
   "link-primary": (
     bg: transparent,
-    color: $primay-color,
-    hover: color.scale($primay-color, $lightness: $hover-darken),
-    active: color.scale($primay-color, $lightness: $active-darken),
+    color: $primary-color,
+    hover: color.scale($primary-color, $lightness: $hover-darken),
+    active: color.scale($primary-color, $lightness: $active-darken),
   ),
   "link-secondary": (
     bg: transparent,
@@ -187,7 +187,7 @@ $btn-colors: (
   }
 }
 $outline-buttons: (
-  "primary": $primay-color,
+  "primary": $primary-color,
   "secondary": $secondary-color,
   "tertiary": $tertiary,
   "success": $success-color,
@@ -227,7 +227,7 @@ $outline-buttons: (
   }
 }
 $ghost-buttons: (
-  "primary": $primay-color,
+  "primary": $primary-color,
   "secondary": $secondary-color,
   "tertiary": $tertiary,
   "success": $success-color,
@@ -258,7 +258,7 @@ $ghost-buttons: (
 }
 
 $text-buttons: (
-  "primary": $primay-color,
+  "primary": $primary-color,
   "secondary": $secondary-color,
   "tertiary": $tertiary,
   "success": $success-color,


### PR DESCRIPTION
## Summary
- rename `$primay-color` to `$primary-color`
- update all component references to use `$primary-color`

## Testing
- `npx ng build kyrolus-sous-materials` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*
- `npm test` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c200651fcc832dba7f1ae62ecdf45c