### PR TITLE
Fix list-none utility selector to target list items

### DIFF
--- a/projects/kyrolus-sous-materials/styles/utilities/_utilities.scss
+++ b/projects/kyrolus-sous-materials/styles/utilities/_utilities.scss
@@ -636,7 +636,7 @@ $background-origin-values: (
 }
 .list-none,
 ul.list-none {
-  &li {
+  li {
     list-style-type: none;
   }
 }


### PR DESCRIPTION
## Summary
- correct `.list-none` utility to target nested list items and remove bullets

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2006730a0832db7e41ec7aea9ee97