### PR TITLE
feat: improve floating position cross-axis handling

### DIFF
--- a/projects/kyrolus-sous-materials/src/directives/floating-ui/floating-ui.directive.spec.ts
+++ b/projects/kyrolus-sous-materials/src/directives/floating-ui/floating-ui.directive.spec.ts
@@ -9,6 +9,7 @@ import { TestBed } from '@angular/core/testing';
 import { FloatingUIDirective } from './floating-ui.directive';
 import { PopoverPlacement } from '../../blocks/popover-menu/popover.types';
 import { By } from '@angular/platform-browser';
+import { FloatingUiService } from './floating-ui.service';
 
 @Component({
   template: `
@@ -253,5 +254,80 @@ describe('1. FloatingUIDirective', () => {
 
     fixtureLocal.destroy();
     expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it(
+    '1.13. should remove right-start when not enough space on bottom for taller float element',
+    () => {
+      const service = TestBed.inject(FloatingUiService);
+      service.setElements(refEl, floatEl);
+
+      vi.spyOn(refEl, 'getBoundingClientRect').mockReturnValue({
+        top: 650,
+        bottom: 700,
+        left: 100,
+        right: 200,
+        width: 100,
+        height: 50,
+      } as DOMRect);
+
+      vi.spyOn(floatEl, 'getBoundingClientRect').mockReturnValue({
+        top: 650,
+        bottom: 850,
+        left: 200,
+        right: 300,
+        width: 100,
+        height: 200,
+      } as DOMRect);
+
+      const result = service.calculateOptimalPosition('right-start', 8);
+
+      expect(result?.avaliablePosition).not.toContain('right-start');
+      expect(result?.avaliablePosition).toContain('right-end');
+    }
+  );
+
+  it('1.14. should shift floating element horizontally when slightly off-screen', () => {
+    const service = TestBed.inject(FloatingUiService);
+    service.setElements(refEl, floatEl);
+
+    vi.spyOn(refEl, 'getBoundingClientRect').mockReturnValue({
+      top: 100,
+      bottom: 150,
+      left: 100,
+      right: 200,
+      width: 100,
+      height: 50,
+    } as DOMRect);
+
+    const floatRects = [
+      {
+        top: 100,
+        bottom: 300,
+        left: -5,
+        right: 95,
+        width: 100,
+        height: 200,
+      } as DOMRect,
+      {
+        top: 100,
+        bottom: 300,
+        left: 0,
+        right: 100,
+        width: 100,
+        height: 200,
+      } as DOMRect,
+    ];
+
+    let call = 0;
+    vi.spyOn(floatEl, 'getBoundingClientRect').mockImplementation(
+      () => floatRects[Math.min(call++, floatRects.length - 1)]
+    );
+
+    Object.defineProperty(floatEl, 'offsetLeft', { value: 0 });
+
+    service.calculateOptimalPosition('bottom', 8);
+
+    expect(floatEl.style.left).toBe('5px');
   });
 });

--- a/projects/kyrolus-sous-materials/src/directives/floating-ui/floating-ui.service.ts
+++ b/projects/kyrolus-sous-materials/src/directives/floating-ui/floating-ui.service.ts
@@ -132,6 +132,63 @@ export class FloatingUiService {
           !['left', 'left-start', 'right', 'right-start'].includes(p)
       );
     }
+
+    // evaluate cross-axis space for start/end variations
+    const extraWidth = Math.max(0, floatRect.width - refRect.width);
+    const extraHeight = Math.max(0, floatRect.height - refRect.height);
+    avaliablePosition = avaliablePosition.filter((pos) => {
+      if (!pos.includes('-')) return true;
+      const [main, align] = pos.split('-');
+
+      if (main === 'top' || main === 'bottom') {
+        // top/bottom placements align horizontally
+        if (align === 'start') {
+          return extraWidth <= spcesArroundRef.right;
+        } else if (align === 'end') {
+          return extraWidth <= spcesArroundRef.left;
+        }
+      } else if (main === 'left' || main === 'right') {
+        // left/right placements align vertically
+        if (align === 'start') {
+          return extraHeight <= spcesArroundRef.bottom;
+        } else if (align === 'end') {
+          return extraHeight <= spcesArroundRef.top;
+        }
+      }
+      return true;
+    });
+
+    // shift floating element back into the viewport if slightly overflowing
+    const tolerance = offset;
+    let shiftX = 0;
+    if (floatRect.left < 0 && Math.abs(floatRect.left) <= tolerance) {
+      shiftX = -floatRect.left;
+    } else if (
+      floatRect.right > viewportWidth &&
+      floatRect.right - viewportWidth <= tolerance
+    ) {
+      shiftX = viewportWidth - floatRect.right;
+    }
+
+    if (shiftX !== 0) {
+      this.floatElement.style.left = `${this.floatElement.offsetLeft + shiftX}px`;
+      floatRect = this.floatElement.getBoundingClientRect();
+    }
+
+    let shiftY = 0;
+    if (floatRect.top < 0 && Math.abs(floatRect.top) <= tolerance) {
+      shiftY = -floatRect.top;
+    } else if (
+      floatRect.bottom > viewportHeight &&
+      floatRect.bottom - viewportHeight <= tolerance
+    ) {
+      shiftY = viewportHeight - floatRect.bottom;
+    }
+
+    if (shiftY !== 0) {
+      this.floatElement.style.top = `${this.floatElement.offsetTop + shiftY}px`;
+      floatRect = this.floatElement.getBoundingClientRect();
+    }
     return {
       avaliablePosition,
       sidesAvaliable,


### PR DESCRIPTION
## Summary
- evaluate cross-axis space when determining available floating UI positions
- shift floating element back into viewport when overflow is small
- add directive tests for cross-axis filtering and viewport shifting

## Testing
- `npm test` *(fails: Application bundle generation failed with TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c20f3c466c832dab33260cde5b4a18