### PR TITLE
feat: improve floating ui placement fallback

### DIFF
--- a/projects/kyrolus-sous-materials/src/directives/floating-ui/floating-ui.directive.spec.ts
+++ b/projects/kyrolus-sous-materials/src/directives/floating-ui/floating-ui.directive.spec.ts
@@ -196,8 +196,7 @@ describe('1. FloatingUIDirective', () => {
     component.adjustPlacement();
     expect(fixture.componentInstance.placement()).toBe(initialPlacement);
   });
-  it('1.10. should return early when there is enough space on all four sides', () => {
-    const initialPlacement = fixture.componentInstance.placement();
+  it('1.10. should choose side with most space when all sides are available', () => {
     vi.spyOn(refEl, 'getBoundingClientRect').mockReturnValue({
       top: 375,
       bottom: 425,
@@ -209,8 +208,7 @@ describe('1. FloatingUIDirective', () => {
 
     // @ts-expect-error: private method
     component.adjustPlacement();
-
-    expect(fixture.componentInstance.placement()).toBe(initialPlacement);
+    expect(fixture.componentInstance.placement()).toBe('left');
   });
   it('1.11. should create and observe with ResizeObserver if available', () => {
     const mockObserve = vi.fn();
@@ -317,5 +315,31 @@ describe('1. FloatingUIDirective', () => {
     component.adjustPlacement();
 
     expect(floatEl.style.left).toBe('5px');
+  });
+  it('1.15. should clamp dimensions when float element exceeds viewport', () => {
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(150);
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(150);
+    vi.spyOn(refEl, 'getBoundingClientRect').mockReturnValue({
+      top: 0,
+      bottom: 50,
+      left: 0,
+      right: 100,
+      width: 100,
+      height: 50,
+    } as DOMRect);
+    vi.spyOn(floatEl, 'getBoundingClientRect').mockReturnValue({
+      top: 0,
+      bottom: 250,
+      left: 0,
+      right: 250,
+      width: 250,
+      height: 250,
+    } as DOMRect);
+    // @ts-expect-error: private method
+    component.adjustPlacement();
+    expect(floatEl.style.maxHeight).toBe('142px');
+    expect(floatEl.style.overflowY).toBe('auto');
+    expect(floatEl.style.maxWidth).toBe('142px');
+    expect(floatEl.style.overflowX).toBe('auto');
   });
 });

--- a/projects/kyrolus-sous-materials/src/directives/floating-ui/floating-ui.directive.ts
+++ b/projects/kyrolus-sous-materials/src/directives/floating-ui/floating-ui.directive.ts
@@ -75,10 +75,49 @@ export class FloatingUIDirective implements OnDestroy {
       this.placement(),
       this.offset()
     );
-    const positions = result ? result.avaliablePosition : [];
-    if (positions.length === 0) return;
-    const optimal: PopoverPlacement = positions[0] as PopoverPlacement;
+    if (!result) return;
+    const {
+      avaliablePosition: positions,
+      sidesAvaliable,
+      spcesArroundRef,
+      floatRect,
+      viewportHeight,
+      viewportWidth,
+    } = result;
 
-    this.placement.set(optimal);
+    let optimal: PopoverPlacement | undefined;
+
+    if (positions.length > 0) {
+      optimal = positions[0] as PopoverPlacement;
+    } else if (sidesAvaliable && sidesAvaliable.size > 0) {
+      let maxSide: string | undefined;
+      let maxSpace = -Infinity;
+      sidesAvaliable.forEach((_, side) => {
+        const space = (spcesArroundRef as any)[side] ?? 0;
+        if (space > maxSpace) {
+          maxSpace = space;
+          maxSide = side;
+        }
+      });
+      if (maxSide) {
+        optimal = maxSide as PopoverPlacement;
+      }
+    }
+
+    if (optimal) {
+      this.placement.set(optimal);
+    }
+
+    if (floatRect) {
+      const margin = this.offset();
+      if (floatRect.height > viewportHeight) {
+        this.floatingElement.style.maxHeight = `${viewportHeight - margin}px`;
+        this.floatingElement.style.overflowY = 'auto';
+      }
+      if (floatRect.width > viewportWidth) {
+        this.floatingElement.style.maxWidth = `${viewportWidth - margin}px`;
+        this.floatingElement.style.overflowX = 'auto';
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- choose placement based on side with most space when no positions available
- clamp floating element within viewport and allow scrolling when oversized
- add tests for fallback side selection and clamping

## Testing
- `npm test` *(fails: Application bundle generation failed)*
- `npx vitest run projects/kyrolus-sous-materials/src/directives/floating-ui/floating-ui.directive.spec.ts` *(fails: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c2db149fe4832db0a58d8c6809c71e