### PR TITLE
feat: adjust placement on scroll

### DIFF
--- a/projects/kyrolus-sous-materials/src/directives/floating-ui/floating-ui.directive.spec.ts
+++ b/projects/kyrolus-sous-materials/src/directives/floating-ui/floating-ui.directive.spec.ts
@@ -65,7 +65,7 @@ describe('1. FloatingUIDirective', () => {
     refEl = fixture.nativeElement.querySelector('div');
     floatEl = fixture.nativeElement.querySelector('[ksFloatingUI]');
     debugElement = fixture.debugElement.query(
-      By.directive(FloatingUIDirective)
+      By.directive(FloatingUIDirective),
     );
     component = debugElement.injector.get(FloatingUIDirective);
     Object.defineProperty(floatEl, 'offsetWidth', { value: 100 });
@@ -308,7 +308,7 @@ describe('1. FloatingUIDirective', () => {
     ];
     let call = 0;
     vi.spyOn(floatEl, 'getBoundingClientRect').mockImplementation(
-      () => floatRects[Math.min(call++, floatRects.length - 1)]
+      () => floatRects[Math.min(call++, floatRects.length - 1)],
     );
     Object.defineProperty(floatEl, 'offsetLeft', { value: 0 });
     // @ts-expect-error: private method
@@ -341,5 +341,22 @@ describe('1. FloatingUIDirective', () => {
     expect(floatEl.style.overflowY).toBe('auto');
     expect(floatEl.style.maxWidth).toBe('142px');
     expect(floatEl.style.overflowX).toBe('auto');
+  });
+
+  it('1.16. should call adjustPlacement on window scroll with debounce', async () => {
+    vi.useFakeTimers();
+    const spy = vi.spyOn<any, any>(component, 'adjustPlacement');
+    window.dispatchEvent(new Event('scroll'));
+    expect(spy).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    await Promise.resolve();
+    expect(spy).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('1.17. should remove scroll listener on destroy', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    fixture.destroy();
+    expect(removeSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
   });
 });


### PR DESCRIPTION
## Summary
- adjust floating UI placement when the window scrolls
- debounce scroll handler and clean up listeners
- cover scroll behavior with new unit tests

## Testing
- `npm test` *(fails: Could not resolve "./models/models.exports")*


------
https://chatgpt.com/codex/tasks/task_e_68c33bd0a858832dae12a76d8d7255ae